### PR TITLE
Protocol not needed since protocol is defined in baseurl

### DIFF
--- a/theme/default/header.php
+++ b/theme/default/header.php
@@ -28,8 +28,8 @@
     <title><?php if(isset($p_title)) { echo $p_title.' - ';}echo $title; ?></title>
     <meta name="description" content="<?php echo $des; ?>" />
     <meta name="keywords" content="<?php echo $keyword; ?>" />
-	<link rel="shortcut icon" href="<?php echo '//' . $baseurl . '/theme/' . $default_theme; ?>/img/favicon.ico">
-    <link href="<?php echo '//' . $baseurl . '/theme/' . $default_theme; ?>/css/paste.css" rel="stylesheet" type="text/css" />
+	<link rel="shortcut icon" href="<?php echo $baseurl . '/theme/' . $default_theme; ?>/img/favicon.ico">
+    <link href="<?php echo $baseurl . '/theme/' . $default_theme; ?>/css/paste.css" rel="stylesheet" type="text/css" />
 <?php
 if (isset($ges_style))
 {

--- a/theme/default/sidebar.php
+++ b/theme/default/sidebar.php
@@ -27,9 +27,9 @@ if(isset($_SESSION['token'])) {
 				<h6>Hello <?php echo ($_SESSION['username']);?>
 					<small>
 						<?php if ( $mod_rewrite == '1' ) {
-							echo '<a href="' . $protocol . $baseurl . '/user/' . $_SESSION['username'] . '" target="_self">' . $lang['mypastes'] . '</a>';
+							echo '<a href="' . $baseurl . '/user/' . $_SESSION['username'] . '" target="_self">' . $lang['mypastes'] . '</a>';
 							} else {
-							echo '<a href="' . $protocol . $baseurl . '/user.php?user=' . $_SESSION['username'] . '" target="_self">' . $lang['mypastes'] . '</a>'; }
+							echo '<a href="' . $baseurl . '/user.php?user=' . $_SESSION['username'] . '" target="_self">' . $lang['mypastes'] . '</a>'; }
 						?>
 					</small>
 				</h6>

--- a/theme/default/view.php
+++ b/theme/default/view.php
@@ -45,7 +45,7 @@ $protocol = ($_SERVER['HTTPS'] == "on")?'https://':'http://';
 					</div>
 
 					<div class="panel-embed col-xs-3" style="display:none; float:right;">
-						<input type="text" class="form-control" value='<?php echo '<script src="' . $protocol . $baseurl . '/embed/'.$paste_id.'"></script>'; ?>' readonly>
+						<input type="text" class="form-control" value='<?php echo '<script src="' . $baseurl . '/embed/'.$paste_id.'"></script>'; ?>' readonly>
 					</div>
                     <div class="clear" style="clear:both;"></div>
                     


### PR DESCRIPTION
I'm open to suggestions on how you want to handle baseurl. I am treating it like WordPress where the protocol is defined in the base url (e.g. `https://mywebsite.com/paste`). By having that in the baseurl, we don't need to define `$protocol` or use the `\\` in `href` links. 