### PR TITLE
get rid of eregi_replace

### DIFF
--- a/mail/mail.php
+++ b/mail/mail.php
@@ -21,7 +21,7 @@ function default_mail($admin_mail, $admin_name, $sent_mail, $subject, $body)
     
     $mail = new PHPMailer();
     
-    $body = eregi_replace("[\]", '', $body);
+    $body = stripslashes ($body);
     
     $mail->AddReplyTo($admin_mail, $admin_name);
     


### PR DESCRIPTION
eregi_replace() is depreciated in PHP7 - see issue #43 