### PR TITLE
Don't echo verification code on error

### DIFF
--- a/verify.php
+++ b/verify.php
@@ -58,7 +58,6 @@ if ($stmt = mysqli_prepare($con, $query)) {
 				}
 
 			} else {
-				echo $ver_code;
 				die("Invalid verification code.");
 			}
 		}


### PR DESCRIPTION
Currently, if the email verification code is wrong, the correct verification code is echoed, which defeats the purpose of verification.

Of course, even with this change, the verification is trivial to bypass if you have access to the source: you can simply concatenate the constants on line 43 to your email and take the MD5 hash. Configurable constants and a different hash function should probably be used to fix this.