### PR TITLE
Remove redundant 'install'.

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -49,7 +49,7 @@ xmlhttp.onreadystatechange=function()
     {
     }
   }
-$.post("install/configure.php", {data_host:sql_host,data_name:sql_name,data_user:sql_user,data_pass:sql_pass,data_sec:sql_sec}, function(results){
+$.post("configure.php", {data_host:sql_host,data_name:sql_name,data_user:sql_user,data_pass:sql_pass,data_sec:sql_sec}, function(results){
 if (results == 0) {
      $("#alertfailed").show();
      $("#install").show();
@@ -86,7 +86,7 @@ $("#alertfailed").hide();
 $("#install").hide();
 $("#configure").hide();
 $("#pre_load").show();
-$.post("install/install.php", {admin_user:user,admin_pass:pass}, function(results){
+$.post("install.php", {admin_user:user,admin_pass:pass}, function(results){
      $("#logpanel").show();
      $("#log").append(results);
      $("#pre_load").hide();


### PR DESCRIPTION
Because the file is already in the 'install' directory having 'install'
again in the relative request path resulted in 'install/install/....',
which produced a 404.

I ran into this problem while installing PASTE, and removing the code change in this pull request fixed the problem.